### PR TITLE
Feat #18 : card component UI

### DIFF
--- a/fe/src/components/Card.tsx
+++ b/fe/src/components/Card.tsx
@@ -1,0 +1,71 @@
+import { colors } from "@constants/colors";
+import { Button } from "./base/Button";
+import { ClosedIcon } from "./icon/ClosedIcon";
+import { EditIcon } from "./icon/EditIcon";
+import { useState } from "react";
+
+export interface CardData {
+  id?: number;
+  name?: string;
+  title?: string;
+  text?: string;
+  writer?: string;
+}
+
+interface CardProps {
+  cardData?: CardData;
+  cardStatus?: "editing" | "normal";
+}
+export const Card = ({ cardData, cardStatus = "normal" }: CardProps) => {
+  const [status, setStatus] = useState(cardStatus);
+
+  const handleClickEdit = () => {
+    setStatus("editing");
+  };
+
+  const handleClickCancelEdit = () => {
+    setStatus("normal");
+  };
+
+  return (
+    <div
+      css={{
+        border: "1px solid black",
+      }}
+    >
+      <div css={{ display: "flex", justifyContent: "space-between" }}>
+        <div css={{ display: "flex", flexDirection: "column" }}>
+          {status === "editing" ? (
+            <>
+              <input type="text" defaultValue={cardData && cardData.title} />
+              <textarea defaultValue={cardData && cardData.text} />
+            </>
+          ) : (
+            <>
+              <div>{cardData && cardData.text}</div>
+              <div>{cardData && cardData.title}</div>
+            </>
+          )}
+          <div> {cardData && `author by ${cardData.writer}`}</div>
+        </div>
+        {status !== "editing" && (
+          <div css={{ right: "0" }}>
+            <Button onClick={() => {}}>
+              <ClosedIcon size={24} rgb={colors.textDefault} />
+            </Button>
+            <Button onClick={handleClickEdit}>
+              <EditIcon size={24} rgb={colors.textDefault} />
+            </Button>
+          </div>
+        )}
+      </div>
+
+      {status === "editing" && (
+        <div css={{ display: "flex", justifyContent: "space-around" }}>
+          <Button variant="gray" text="취소" onClick={handleClickCancelEdit} />
+          <Button variant="blue" text="등록" onClick={() => {}} />
+        </div>
+      )}
+    </div>
+  );
+};

--- a/fe/src/components/Column/Column.tsx
+++ b/fe/src/components/Column/Column.tsx
@@ -22,8 +22,8 @@ export const Column = ({ columnId, columnName, cards }: ColumnDataProps) => {
         handleClickAddCard={handleClickAddCard}
       />
       {isAdding && <Card cardStatus={"editing"} />}
-      {cards.map((CardData, index) => (
-        <Card key={`${index}_${CardData.id}`} cardData={CardData} />
+      {cards.map((cardData, index) => (
+        <Card key={`${index}_${cardData.id}`} cardData={cardData} />
       ))}
     </div>
   );

--- a/fe/src/components/Column/Column.tsx
+++ b/fe/src/components/Column/Column.tsx
@@ -1,15 +1,15 @@
 import { useState } from "react";
-import { Card } from "../types";
 import { ColumnHeader } from "./ColumnHeader";
+import { Card, CardData } from "@components/Card";
 
 interface ColumnDataProps {
   columnId: number;
   columnName: string;
-  cards: Card[];
+  cards: CardData[];
 }
 
 export const Column = ({ columnId, columnName, cards }: ColumnDataProps) => {
-  const [isAdding, setIsAdding] = useState<boolean>(false);
+  const [isAdding, setIsAdding] = useState<boolean>(true);
   const handleClickAddCard = () => setIsAdding(true);
   const cardCount = cards.length;
 
@@ -21,6 +21,10 @@ export const Column = ({ columnId, columnName, cards }: ColumnDataProps) => {
         cardCount={cardCount}
         handleClickAddCard={handleClickAddCard}
       />
+      {isAdding && <Card cardStatus={"editing"} />}
+      {cards.map((CardData, index) => (
+        <Card key={`${index}_${CardData.id}`} cardData={CardData} />
+      ))}
     </div>
   );
 };

--- a/fe/src/components/types.ts
+++ b/fe/src/components/types.ts
@@ -1,7 +1,0 @@
-export interface Card {
-  id?: number;
-  name?: string;
-  title?: string;
-  text?: string;
-  writer?: string;
-}

--- a/fe/src/mocks/data.ts
+++ b/fe/src/mocks/data.ts
@@ -1,7 +1,7 @@
-import { Card } from "@components/types";
+import { CardData } from "@components/Card";
 import { faker } from "@faker-js/faker";
 
-export function createRandomCard(): Card {
+export function createRandomCard(): CardData {
   return {
     id: Number(faker.string.uuid()),
     name: faker.internet.userName(),
@@ -11,6 +11,6 @@ export function createRandomCard(): Card {
   };
 }
 
-export const CARDS: Card[] = faker.helpers.multiple(createRandomCard, {
+export const CARDS: CardData[] = faker.helpers.multiple(createRandomCard, {
   count: 100,
 });


### PR DESCRIPTION
## What is this PR?
card component UI를 구현한 PR 입니다.

## Key changes
- card component 한 곳에서 수정/추가 와 일반 보기 상태를 함께 가능하게 구현했습니다.
- types에 따로 type을 놓는것 보다 component 내에서 놓는게 더 괜찮다 판다해서 파일을 삭제 했습니다.
- isAdding 상태인 경우 card list 최상당엔 추가하기 상태인 card component가 활성화 되게 구현했습니다.

## To reviewers
- css는 element가 정렬되는 정도만 했습니다.
- font나 그 외 Typography 같은 경우에는 아무것도 적용 안했습니다.
- 수정하기 / 취소 정도의 클릭 이벤트만 적용되어 있습니다.
- card component에서 isAdding 상태 에서 취소를 눌렀을 경우 추가하기 상태인 card component를 닫는 기능은 구현하지 못했습니다.
  - 좀 더 디테일한 기능 구현을 하며 추가 할 예정 입니다.


  Close #18