### PR TITLE
feat #35 : 삭제 확인 모달창 구현

### DIFF
--- a/fe/src/components/Card.tsx
+++ b/fe/src/components/Card.tsx
@@ -2,6 +2,7 @@ import { colors } from "@constants/colors";
 import { useFetch } from "hooks/useFetch";
 import { useState } from "react";
 import { Button } from "./base/Button";
+import { RemoveModal } from "./base/RemoveModal";
 import { ClosedIcon } from "./icon/ClosedIcon";
 import { EditIcon } from "./icon/EditIcon";
 
@@ -20,6 +21,7 @@ export const Card = ({ cardData, updateColumnList }: CardProps) => {
   const [status, setStatus] = useState("normal");
   const [title, setTitle] = useState(cardData.title);
   const [content, setContent] = useState(cardData.content);
+  const [isOpenModal, setIsOpenModal] = useState(false);
 
   const {
     errorMsg: errorMsgDelete,
@@ -42,6 +44,14 @@ export const Card = ({ cardData, updateColumnList }: CardProps) => {
       changedCardContent: content,
     },
   });
+
+  const openModal = () => {
+    setIsOpenModal(true);
+  };
+
+  const closeModal = () => {
+    setIsOpenModal(false);
+  };
 
   const handleClickRemove = async () => {
     await fetchDelete();
@@ -97,7 +107,7 @@ export const Card = ({ cardData, updateColumnList }: CardProps) => {
         </div>
         {status !== "editing" && (
           <div css={{ right: "0" }}>
-            <Button onClick={handleClickRemove}>
+            <Button onClick={openModal}>
               <ClosedIcon size={24} rgb={colors.textDefault} />
             </Button>
             <Button onClick={handleClickEdit}>
@@ -113,6 +123,13 @@ export const Card = ({ cardData, updateColumnList }: CardProps) => {
           <Button variant="blue" text="등록" onClick={handleClickUpdate} />
         </div>
       )}
+
+      <RemoveModal
+        isOpen={isOpenModal}
+        removeHandler={handleClickRemove}
+        closeHandler={closeModal}
+        text={"카드 삭제"}
+      />
     </div>
   );
 };

--- a/fe/src/components/base/Button.tsx
+++ b/fe/src/components/base/Button.tsx
@@ -48,7 +48,7 @@ const VARIANTS = {
   },
   red: {
     color: colors.textWhiteDefault,
-    background: colors.surfaceDanger,
+    background: colors.red,
   },
   gray: {
     color: colors.textDefault,

--- a/fe/src/components/base/RemoveModal.tsx
+++ b/fe/src/components/base/RemoveModal.tsx
@@ -1,3 +1,5 @@
+import { dropShadow, radius } from "@constants/objectStyle";
+import { css } from "@emotion/react";
 import { useEffect, useRef } from "react";
 import { Button } from "./Button";
 
@@ -27,15 +29,18 @@ export const RemoveModal = ({
 
   return (
     <dialog
-      css={{
-        width: "320px",
-        height: "126px",
-        padding: "24px",
-        boxSizing: "border-box",
-        "&::backdrop": {
-          background: "rgba(0, 0, 0, 0.3)",
-        },
-      }}
+      css={css`
+        width: 320px;
+        height: 126px;
+        padding: 24px;
+        box-sizing: border-box;
+        border: none;
+        &::backdrop {
+          background: rgba(0, 0, 0, 0.3);
+        }
+        ${radius.radius8}
+        ${dropShadow.up}
+      `}
       ref={modalRef}
       onClose={handleClickClose}
     >

--- a/fe/src/components/base/RemoveModal.tsx
+++ b/fe/src/components/base/RemoveModal.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useRef } from "react";
+import { Button } from "./Button";
+
+interface CancelModalProps {
+  text: string;
+  isOpen: boolean;
+  removeHandler: () => void;
+  closeHandler: () => void;
+}
+
+export const RemoveModal = ({
+  text,
+  isOpen,
+  removeHandler,
+  closeHandler,
+}: CancelModalProps) => {
+  const modalRef = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    isOpen && modalRef.current?.showModal();
+  }, [isOpen]);
+
+  const handleClickClose = () => {
+    closeHandler();
+    modalRef.current?.close();
+  };
+
+  return (
+    <dialog
+      css={{
+        width: "320px",
+        height: "126px",
+        padding: "24px",
+        boxSizing: "border-box",
+        "&::backdrop": {
+          background: "rgba(0, 0, 0, 0.3)",
+        },
+      }}
+      ref={modalRef}
+      onClose={handleClickClose}
+    >
+      <div
+        css={{
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+        }}
+      >
+        <div>{text}</div>
+        <div css={{ display: "flex", justifyContent: "space-between" }}>
+          <Button variant="gray" onClick={handleClickClose} text="취소" />
+          <Button variant="red" onClick={removeHandler} text="삭제" />
+        </div>
+      </div>
+    </dialog>
+  );
+};

--- a/fe/src/constants/objectStyle.ts
+++ b/fe/src/constants/objectStyle.ts
@@ -1,0 +1,27 @@
+import { css } from "@emotion/react";
+
+export const radius = {
+  radius8: css`
+    border-radius: 8px;
+  `,
+  radius16: css`
+    border-radius: 16px;
+  `,
+  radius50: (height: number) => css`
+    border-radius: ${height / 50}px;
+  `,
+};
+
+export const dropShadow = {
+  normal: css`
+    box-shadow: 0px 1px 4px rgba(110, 128, 145, 0.24);
+  `,
+  up: css`
+    box-shadow: 0px 2px 8px rgba(110, 128, 145, 0.32);
+    backdrop-filter: blur(4px);
+  `,
+  floating: css`
+    box-shadow: 0px 0px 4px rgba(110, 128, 145, 0.08),
+      0px 16px 16px rgba(110, 128, 145, 0.24);
+  `,
+};


### PR DESCRIPTION
## What is this PR?
- 카드 삭제와, 히스토리 삭제에 사용할 삭제 확인 모달 컴포넌트 구현했습니다.
- 공용으로 사용하게 될 objectStyle이 필요합니다.
  - radius, dropShadow

## Key changes
- Button 컴포넌트 내부 VARIANTS에 red background 수정했습니다.
- 공용으로 사용할 objectStyle을 추가하고 modal에 적용했습니다.

## To reviewers

  Close #35 