### PR TITLE
feat #24, refactor #33: 새로운 카드 등록 버튼 기능 추가, Button Component 리팩토링

### DIFF
--- a/fe/src/components/Card.tsx
+++ b/fe/src/components/Card.tsx
@@ -22,6 +22,8 @@ export const Card = ({ cardData, updateColumnList }: CardProps) => {
   const [title, setTitle] = useState(cardData.title);
   const [content, setContent] = useState(cardData.content);
   const [isOpenModal, setIsOpenModal] = useState(false);
+  const isChanged = cardData.title !== title || cardData.content !== content;
+  const isAllFilled = !!title && !!content;
 
   const {
     errorMsg: errorMsgDelete,
@@ -59,10 +61,14 @@ export const Card = ({ cardData, updateColumnList }: CardProps) => {
   };
 
   const handleClickUpdate = async () => {
-    if (cardData.title !== title || cardData.content !== content) {
+    if (isChanged && isAllFilled) {
       setStatus("normal");
       await fetchUpdate();
       updateColumnList();
+    }
+
+    if (!isChanged) {
+      setStatus("normal");
     }
   };
 
@@ -107,7 +113,11 @@ export const Card = ({ cardData, updateColumnList }: CardProps) => {
         </div>
         {status !== "editing" && (
           <div css={{ right: "0" }}>
-            <Button pattern="icon" onClick={openModal}>
+            <Button
+              pattern="icon"
+              onClick={openModal}
+              iconHoverColor={colors.red}
+            >
               <ClosedIcon size={24} rgb={colors.textDefault} />
             </Button>
             <Button pattern="icon" onClick={handleClickEdit}>
@@ -122,8 +132,13 @@ export const Card = ({ cardData, updateColumnList }: CardProps) => {
           <Button pattern="text" variant="gray" onClick={handleClickCancelEdit}>
             <span>취소</span>
           </Button>
-          <Button pattern="text" variant="blue" onClick={handleClickUpdate}>
-            <span>등록</span>
+          <Button
+            pattern="text"
+            variant="blue"
+            onClick={handleClickUpdate}
+            disabled={!isAllFilled}
+          >
+            <span>저장</span>
           </Button>
         </div>
       )}

--- a/fe/src/components/Card.tsx
+++ b/fe/src/components/Card.tsx
@@ -1,10 +1,10 @@
+import { Button } from "@components/base/Button";
+import { RemoveModal } from "@components/base/RemoveModal";
+import { ClosedIcon } from "@components/icon/ClosedIcon";
+import { EditIcon } from "@components/icon/EditIcon";
 import { colors } from "@constants/colors";
 import { useFetch } from "hooks/useFetch";
 import { useState } from "react";
-import { Button } from "./base/Button";
-import { RemoveModal } from "./base/RemoveModal";
-import { ClosedIcon } from "./icon/ClosedIcon";
-import { EditIcon } from "./icon/EditIcon";
 
 export interface CardData {
   cardId: number;
@@ -107,10 +107,10 @@ export const Card = ({ cardData, updateColumnList }: CardProps) => {
         </div>
         {status !== "editing" && (
           <div css={{ right: "0" }}>
-            <Button onClick={openModal}>
+            <Button pattern="icon" onClick={openModal}>
               <ClosedIcon size={24} rgb={colors.textDefault} />
             </Button>
-            <Button onClick={handleClickEdit}>
+            <Button pattern="icon" onClick={handleClickEdit}>
               <EditIcon size={24} rgb={colors.textDefault} />
             </Button>
           </div>
@@ -119,8 +119,12 @@ export const Card = ({ cardData, updateColumnList }: CardProps) => {
 
       {status === "editing" && (
         <div css={{ display: "flex", justifyContent: "space-around" }}>
-          <Button variant="gray" text="취소" onClick={handleClickCancelEdit} />
-          <Button variant="blue" text="등록" onClick={handleClickUpdate} />
+          <Button pattern="text" variant="gray" onClick={handleClickCancelEdit}>
+            <span>취소</span>
+          </Button>
+          <Button pattern="text" variant="blue" onClick={handleClickUpdate}>
+            <span>등록</span>
+          </Button>
         </div>
       )}
 

--- a/fe/src/components/Column/Badge.tsx
+++ b/fe/src/components/Column/Badge.tsx
@@ -1,23 +1,13 @@
 import { colors } from "@constants/colors";
 import { typography } from "@constants/font";
+import { radius } from "@constants/objectStyle";
+import { css } from "@emotion/react";
 
 export const Badge = ({ cardCount }: { cardCount: number }) => {
   const isMoreTwoDigits = cardCount > 99;
 
   return (
-    <div
-      css={{
-        display: "flex",
-        justifyContent: "center",
-        alignItems: "center",
-        width: "1.5rem",
-        height: "1.5rem",
-        border: `1px solid ${colors.borderDefault}`,
-        padding: "0px, 4px",
-        borderRadius: "8px",
-        color: colors.textWeak,
-      }}
-    >
+    <div css={badgeStyle(isMoreTwoDigits)}>
       <span
         css={{
           ...typography.display.medium[12],
@@ -28,3 +18,14 @@ export const Badge = ({ cardCount }: { cardCount: number }) => {
     </div>
   );
 };
+
+const badgeStyle = (isMoreTwoDigits: boolean) => css`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 1.5rem;
+  width: ${isMoreTwoDigits ? "40px" : "1.5rem"};
+  border: 1px solid ${colors.borderDefault};
+  color: ${colors.textWeak};
+  ${radius.radius8};
+`;

--- a/fe/src/components/Column/ColumnHeader.tsx
+++ b/fe/src/components/Column/ColumnHeader.tsx
@@ -33,10 +33,18 @@ export const ColumnHeader = ({
         <Badge cardCount={cardCount} />
       </div>
       <div css={{ display: "flex" }}>
-        <Button onClick={handleClickAddCard}>
+        <Button
+          pattern="icon"
+          onClick={handleClickAddCard}
+          iconHoverColor={colors.surfaceBrand}
+        >
           <PlusIcon size={24} rgb={colors.textWeak} />
         </Button>
-        <Button onClick={handleClickRemoveColumn}>
+        <Button
+          pattern="icon"
+          onClick={handleClickRemoveColumn}
+          iconHoverColor={colors.textDanger}
+        >
           <ClosedIcon size={24} rgb={colors.textWeak} />
         </Button>
       </div>

--- a/fe/src/components/Header.tsx
+++ b/fe/src/components/Header.tsx
@@ -10,7 +10,7 @@ export const Header = () => {
   return (
     <div>
       <div>TODO LIST</div>
-      <Button onClick={historyFun}>
+      <Button pattern="icon" onClick={historyFun}>
         <HistoryIcon size={24} rgb={colors.textDefault} />
       </Button>
     </div>

--- a/fe/src/components/NewCard.tsx
+++ b/fe/src/components/NewCard.tsx
@@ -10,7 +10,7 @@ export const NewCard: React.FC<{
 }> = ({ columnId, nextCardId, handleClickCancelAdd, updateColumnList }) => {
   const [title, setTitle] = useState("");
   const [content, setContent] = useState("");
-  const { response: newCard, fetch: fetchAdd } = useFetch({
+  const { fetch: fetchAdd } = useFetch({
     url: "/api/cards",
     method: "post",
     body: {
@@ -20,6 +20,7 @@ export const NewCard: React.FC<{
       nextCardId: nextCardId,
     },
   });
+  const isAllFilled = !!title && !!content;
 
   const handleChangeTitle = (e: React.ChangeEvent<HTMLInputElement>) => {
     setTitle(e.target.value);
@@ -49,8 +50,17 @@ export const NewCard: React.FC<{
         </div>
       </div>
       <div css={{ display: "flex", justifyContent: "space-around" }}>
-        <Button variant="gray" text="취소" onClick={handleClickCancelAdd} />
-        <Button variant="blue" text="등록" onClick={handleClickAdd} />
+        <Button pattern="text" variant="gray" onClick={handleClickCancelAdd}>
+          <span>취소</span>
+        </Button>
+        <Button
+          pattern="text"
+          variant="blue"
+          onClick={handleClickAdd}
+          disabled={!isAllFilled}
+        >
+          <span>등록</span>
+        </Button>
       </div>
     </div>
   );

--- a/fe/src/components/base/Button.tsx
+++ b/fe/src/components/base/Button.tsx
@@ -1,4 +1,5 @@
 import { colors } from "@constants/colors";
+import { radius } from "@constants/objectStyle";
 import { css } from "@emotion/react";
 import { ButtonHTMLAttributes } from "react";
 
@@ -37,11 +38,11 @@ const buttonStyle = ({
   return css`
     width: ${pattern === "text" ? "132px" : "auto"};
     height: ${pattern === "text" ? "32px" : "auto"};
-    outline: "none";
-    padding: "4px";
-    display: "flex";
-    justify-content: "center";
-    align-items: "center";
+    outline: none;
+    padding: 4px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
     &:hover {
       opacity: 0.8;
       & svg,
@@ -50,11 +51,12 @@ const buttonStyle = ({
       }
     }
     &:disabled {
-      cursor: "default";
+      cursor: default;
       opacity: 0.3;
     }
     color: ${VARIANTS[variant].color};
     background: ${VARIANTS[variant].background};
+    ${pattern === "text" && radius.radius8}
   `;
 };
 

--- a/fe/src/components/base/Button.tsx
+++ b/fe/src/components/base/Button.tsx
@@ -1,44 +1,61 @@
 import { colors } from "@constants/colors";
+import { css } from "@emotion/react";
 import { ButtonHTMLAttributes } from "react";
 
+type ButtonVariant = "blue" | "red" | "gray" | "transparent";
+type ButtonPattern = "text" | "icon";
+
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  variant?: "blue" | "red" | "gray" | "transparent";
-  text?: string;
-  onClick: () => void;
+  variant?: ButtonVariant;
+  pattern: ButtonPattern;
+  iconHoverColor?: string;
 }
 
 export const Button = ({
   variant = "transparent",
-  text,
-  onClick,
+  pattern,
+  iconHoverColor,
   children,
+  ...props
 }: ButtonProps) => {
   return (
-    <button
-      css={{
-        outline: "none",
-        padding: "4px",
-        display: "flex",
-        justifyContent: "space-between",
-        alignItems: "center",
-        ...VARIANTS[variant],
-      }}
-      onClick={onClick}
-    >
+    <button css={buttonStyle({ variant, pattern, iconHoverColor })} {...props}>
       {children}
-      {text && (
-        <div
-          css={{
-            padding: "4px",
-            width: "45px",
-            height: "17px",
-          }}
-        >
-          {text}
-        </div>
-      )}
     </button>
   );
+};
+
+const buttonStyle = ({
+  pattern,
+  variant = "transparent",
+  iconHoverColor,
+}: {
+  variant?: ButtonVariant;
+  pattern: ButtonPattern;
+  iconHoverColor?: string;
+}) => {
+  return css`
+    width: ${pattern === "text" ? "132px" : "auto"};
+    height: ${pattern === "text" ? "32px" : "auto"};
+    outline: "none";
+    padding: "4px";
+    display: "flex";
+    justify-content: "center";
+    align-items: "center";
+    &:hover {
+      opacity: 0.8;
+      & svg,
+      path {
+        fill: ${iconHoverColor};
+      }
+    }
+    &:disabled {
+      cursor: "default";
+      opacity: 0.3;
+    }
+    color: ${VARIANTS[variant].color};
+    background: ${VARIANTS[variant].background};
+  `;
 };
 
 const VARIANTS = {

--- a/fe/src/components/base/RemoveModal.tsx
+++ b/fe/src/components/base/RemoveModal.tsx
@@ -54,8 +54,12 @@ export const RemoveModal = ({
       >
         <div>{text}</div>
         <div css={{ display: "flex", justifyContent: "space-between" }}>
-          <Button variant="gray" onClick={handleClickClose} text="취소" />
-          <Button variant="red" onClick={removeHandler} text="삭제" />
+          <Button pattern="text" variant="gray" onClick={handleClickClose}>
+            <span>취소</span>
+          </Button>
+          <Button pattern="text" variant="red" onClick={removeHandler}>
+            <span>삭제</span>
+          </Button>
         </div>
       </div>
     </dialog>


### PR DESCRIPTION
## What is this PR?
- icon, text pattern에 따라 width, height 값 설정
- 컴포넌트 구조에 필요한 prop이 아닌 경우 ...props로 버튼 기본 attribute 추가
- 카드의 [등록 버튼]은 title, content가 모두 입력되면 활성화되고, 그렇지 않으면 disabled 상태
- Card, Header, Modal 내부의 버튼 컴포넌트 변경 사항 반영

## Key changes
- Button component 필수 prop으로 pattern을 추가하여 pattern value에 따라 width, height가 결정됩니다.
- 대신 text props를 삭제하고, children으로 추가하도록 했어요!  
- Button hover 시 하위 아이콘을 어떤 색상으로 변경할지 optional props로 추가했습니다.

## To reviewers
- 버튼 pattern보다 size가 더 적절할까 하는 생각이 드는데, 일단 피그마 그대로 했어요.
- 제이 의견이랑 border-radius까지 반영하고 draft 풀게요!

Close #24 #33 