### PR TITLE
feat #43: Text Component 생성

### DIFF
--- a/fe/src/components/Column/ColumnHeader.tsx
+++ b/fe/src/components/Column/ColumnHeader.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@components/base/Button";
+import { Text } from "@components/base/Text";
 import { ClosedIcon } from "@components/icon/ClosedIcon";
 import { PlusIcon } from "@components/icon/PlusIcon";
 import { colors } from "@constants/colors";
@@ -29,7 +30,9 @@ export const ColumnHeader = ({
       }}
     >
       <div css={{ display: "flex", gap: "4px", alignItems: "center" }}>
-        <span css={{ ...typography.display.bold[16] }}>{columnName}</span>
+        <Text typography={typography.display.bold[16]} color={colors.textBold}>
+          {columnName}
+        </Text>
         <Badge cardCount={cardCount} />
       </div>
       <div css={{ display: "flex" }}>
@@ -43,7 +46,7 @@ export const ColumnHeader = ({
         <Button
           pattern="icon"
           onClick={handleClickRemoveColumn}
-          iconHoverColor={colors.textDanger}
+          iconHoverColor={colors.red}
         >
           <ClosedIcon size={24} rgb={colors.textWeak} />
         </Button>

--- a/fe/src/components/base/Text.tsx
+++ b/fe/src/components/base/Text.tsx
@@ -1,10 +1,15 @@
+import { colors } from "@constants/colors";
 import { HTMLAttributes } from "react";
 
 interface Props extends HTMLAttributes<HTMLSpanElement> {
   typography?: object;
-  color: string;
+  color?: string;
 }
-export function Text({ typography, color, ...props }: Props) {
+export function Text({
+  typography,
+  color = colors.textDefault,
+  ...props
+}: Props) {
   return (
     <span
       css={{

--- a/fe/src/components/base/Text.tsx
+++ b/fe/src/components/base/Text.tsx
@@ -1,0 +1,17 @@
+import { HTMLAttributes } from "react";
+
+interface Props extends HTMLAttributes<HTMLSpanElement> {
+  typography?: object;
+  color: string;
+}
+export function Text({ typography, color, ...props }: Props) {
+  return (
+    <span
+      css={{
+        color,
+        ...typography,
+      }}
+      {...props}
+    />
+  );
+}


### PR DESCRIPTION
## What is this PR?
- span 태그 사용 시 필요한 props를 설정한 Text Component를 생성하였습니다.

## Key changes
- Text 컴포넌트 생성

## To reviewers
- 저번에 한번 얘기 나왔던 부분인데 span 태그를 통일적으로 사용하기 위해 만들었습니다. 이후 작업 때 적용하시도록 미리 PR 보내요!
- 피그마에 있는 그대로 typography, color props로 넘겨주면 됩니다!
- ColumnHeader 에 적용한 예시도 포함했어요.