### PR TITLE
refactor #40 : card move 성능 개선, 오류 수정

### DIFF
--- a/fe/src/components/Card/Card.tsx
+++ b/fe/src/components/Card/Card.tsx
@@ -3,14 +3,14 @@ import { RemoveModal } from "@components/base/RemoveModal";
 import { dropShadow, radius } from "@constants/objectStyle";
 import { css } from "@emotion/react";
 import { useFetch } from "hooks/useFetch";
-import React, { HTMLAttributes, memo, useEffect, useState } from "react";
+import React, { memo, useEffect, useState } from "react";
 import { CardEditor } from "./CardEditor";
 import { CardViewer } from "./CardViewer";
 
-export interface CardData extends HTMLAttributes<HTMLDivElement> {
+export interface CardData {
   cardId: number;
-  title: string;
-  content: string;
+  cardTitle: string;
+  cardContent: string;
   writer: string;
 }
 
@@ -87,7 +87,7 @@ export const Card = memo(
 
     return (
       <div
-        css={[cardStyle, `${isDragging && "display: none"};`]}
+        css={[cardStyle, isDragging && { display: "none" }]}
         onMouseDown={onMouseDownHandler}
         onMouseMove={onMouseMoveHandler}
       >

--- a/fe/src/components/Card/Card.tsx
+++ b/fe/src/components/Card/Card.tsx
@@ -3,7 +3,7 @@ import { RemoveModal } from "@components/base/RemoveModal";
 import { dropShadow, radius } from "@constants/objectStyle";
 import { css } from "@emotion/react";
 import { useFetch } from "hooks/useFetch";
-import { HTMLAttributes, useEffect, useState } from "react";
+import React, { HTMLAttributes, memo, useEffect, useState } from "react";
 import { CardEditor } from "./CardEditor";
 import { CardViewer } from "./CardViewer";
 
@@ -20,97 +20,103 @@ interface CardProps {
   setCloneCard: (CardData: CardData, initialPosition: Position) => void;
 }
 
-export const Card = ({ cardData, onCardChanged, setCloneCard }: CardProps) => {
-  const [status, setStatus] = useState<"viewer" | "editor">("viewer");
-  const [isMouseDown, setIsMouseDown] = useState(false);
-  const [isDragging, setIsDragging] = useState(false);
-  const [isOpenModal, setIsOpenModal] = useState(false);
+export const Card = memo(
+  ({ cardData, onCardChanged, setCloneCard }: CardProps) => {
+    const [status, setStatus] = useState<"viewer" | "editor">("viewer");
+    const [isMouseDown, setIsMouseDown] = useState(false);
+    const [isDragging, setIsDragging] = useState(false);
+    const [isOpenModal, setIsOpenModal] = useState(false);
 
-  const { fetch: fetchDelete } = useFetch({
-    url: `/api/cards/${cardData.cardId}`,
-    method: "delete",
-  });
+    const { fetch: fetchDelete } = useFetch({
+      url: `/api/cards/${cardData.cardId}`,
+      method: "delete",
+    });
 
-  const onClickEdit = () => {
-    setStatus("editor");
-  };
-
-  const exitEdit = () => {
-    setStatus("viewer");
-  };
-
-  const onSubmit = () => {
-    onCardChanged();
-    exitEdit();
-  };
-
-  const openModal = () => {
-    setIsOpenModal(true);
-  };
-
-  const closeModal = () => {
-    setIsOpenModal(false);
-  };
-
-  const onClickRemove = async () => {
-    await fetchDelete();
-    onCardChanged();
-  };
-
-  const onMouseDownHandler = (e: React.MouseEvent) => {
-    e.preventDefault();
-    setIsMouseDown(true);
-  };
-
-  const onMouseMoveHandler = (e: React.MouseEvent) => {
-    if (isMouseDown) {
-      setCloneCard(cardData, { x: e.clientX, y: e.clientY });
-      setIsDragging(true);
-    }
-  };
-
-  const onMouseUpHandler = () => {
-    setIsMouseDown(false);
-  };
-
-  useEffect(() => {
-    window.addEventListener("mouseup", onMouseUpHandler);
-    return () => {
-      window.removeEventListener("mouseup", onMouseUpHandler);
+    const onClickEdit = () => {
+      setStatus("editor");
     };
-  }, []);
 
-  return (
-    <div
-      css={[cardStyle, `${isDragging && "display: none"};`]}
-      onMouseDown={onMouseDownHandler}
-      onMouseMove={onMouseMoveHandler}
-    >
-      {status === "viewer" ? (
-        <>
-          <CardViewer
-            onClickEdit={onClickEdit}
-            onClickRemove={openModal}
+    const exitEdit = () => {
+      setStatus("viewer");
+    };
+
+    const onSubmit = () => {
+      onCardChanged();
+      exitEdit();
+    };
+
+    const openModal = () => {
+      setIsOpenModal(true);
+    };
+
+    const closeModal = () => {
+      setIsOpenModal(false);
+    };
+
+    const onClickRemove = async () => {
+      await fetchDelete();
+      onCardChanged();
+    };
+
+    const onMouseDownHandler = (e: React.MouseEvent) => {
+      e.preventDefault();
+      if ((e.target as Element).tagName !== "BUTTON") {
+        setIsMouseDown(true);
+      }
+    };
+
+    const onMouseMoveHandler = (e: React.MouseEvent) => {
+      e.preventDefault();
+      if ((e.target as Element).tagName !== "BUTTON" && isMouseDown) {
+        setCloneCard(cardData, { x: e.clientX, y: e.clientY });
+        setIsDragging(true);
+      }
+    };
+
+    const onMouseUpHandler = () => {
+      setIsMouseDown(false);
+      setIsDragging(false);
+    };
+
+    useEffect(() => {
+      window.addEventListener("mouseup", onMouseUpHandler);
+      return () => {
+        window.removeEventListener("mouseup", onMouseUpHandler);
+      };
+    }, []);
+
+    return (
+      <div
+        css={[cardStyle, `${isDragging && "display: none"};`]}
+        onMouseDown={onMouseDownHandler}
+        onMouseMove={onMouseMoveHandler}
+      >
+        {status === "viewer" ? (
+          <>
+            <CardViewer
+              onClickEdit={onClickEdit}
+              onClickRemove={openModal}
+              cardData={cardData}
+            />
+            <RemoveModal
+              isOpen={isOpenModal}
+              removeHandler={onClickRemove}
+              closeHandler={closeModal}
+              text={"카드 삭제"}
+            />
+          </>
+        ) : (
+          <CardEditor
             cardData={cardData}
+            type="edit"
+            onCancel={exitEdit}
+            onSubmit={onSubmit}
           />
-          <RemoveModal
-            isOpen={isOpenModal}
-            removeHandler={onClickRemove}
-            closeHandler={closeModal}
-            text={"카드 삭제"}
-          />
-        </>
-      ) : (
-        <CardEditor
-          cardData={cardData}
-          type="edit"
-          onCancel={exitEdit}
-          onSubmit={onSubmit}
-        />
-      )}
-    </div>
-  );
-};
+        )}
+      </div>
+    );
+  }
+);
 
 export const cardStyle = () => {
   return css`

--- a/fe/src/components/Card/CardEditor.tsx
+++ b/fe/src/components/Card/CardEditor.tsx
@@ -21,8 +21,8 @@ export const CardEditor = ({
   onCancel,
   onSubmit,
 }: CardEditorProps) => {
-  const [title, setTitle] = useState(cardData?.title || "");
-  const [content, setContent] = useState(cardData?.content || "");
+  const [title, setTitle] = useState(cardData?.cardTitle || "");
+  const [content, setContent] = useState(cardData?.cardContent || "");
   const isAllFilled = !!title && !!content;
 
   const { fetch: fetchAdd } = useFetch({
@@ -54,8 +54,8 @@ export const CardEditor = ({
 
   const handleClickCancel = () => {
     onCancel();
-    setTitle(cardData?.title || "");
-    setContent(cardData?.content || "");
+    setTitle(cardData?.cardTitle || "");
+    setContent(cardData?.cardContent || "");
   };
 
   const handleClickSubmit = async () => {

--- a/fe/src/components/Card/CardViewer.tsx
+++ b/fe/src/components/Card/CardViewer.tsx
@@ -16,7 +16,7 @@ export const CardViewer = ({
   onClickEdit,
   onClickRemove,
 }: CardViewerProps) => {
-  const { cardTitle: title, cardContent: content, writer } = cardData;
+  const { cardTitle, cardContent, writer } = cardData;
 
   return (
     <div
@@ -34,14 +34,14 @@ export const CardViewer = ({
             css={{ height: "17px", color: COLOR_VARIANTS.textStrong }}
             typography="displayBold14"
           >
-            {title}
+            {cardTitle}
           </Text>
 
           <Text
             css={{ height: "17px", color: COLOR_VARIANTS.textDefault }}
             typography="displayBold14"
           >
-            {content}
+            {cardContent}
           </Text>
         </div>
         <Text

--- a/fe/src/components/Card/CardViewer.tsx
+++ b/fe/src/components/Card/CardViewer.tsx
@@ -7,8 +7,8 @@ import { CardData } from "./Card";
 
 interface CardViewerProps {
   cardData: CardData;
-  onClickEdit: () => void;
-  onClickRemove: () => void;
+  onClickEdit?: () => void;
+  onClickRemove?: () => void;
 }
 
 export const CardViewer = ({
@@ -16,7 +16,7 @@ export const CardViewer = ({
   onClickEdit,
   onClickRemove,
 }: CardViewerProps) => {
-  const { title, content, writer } = cardData;
+  const { cardTitle: title, cardContent: content, writer } = cardData;
 
   return (
     <div

--- a/fe/src/components/Card/CloneCard.tsx
+++ b/fe/src/components/Card/CloneCard.tsx
@@ -17,18 +17,19 @@ export const CloneCard = memo(
   }) => {
     const cardRef = useRef<HTMLDivElement>(null);
 
-    useEffect(() => {
-      if (cardRef.current) {
-        cardRef.current.style.left = `${initialPosition.x - 150}px`;
-        cardRef.current.style.top = `${initialPosition.y - 44}px`;
-      }
-    }, [initialPosition]);
-
     const moveCard = useCallback((e: MouseEvent) => {
+      editPoint({ x: e.clientX, y: e.clientY });
+    }, []);
+
+    const editPoint = (point: Position) => {
       if (cardRef.current) {
-        cardRef.current.style.left = `${e.clientX - 150}px`;
-        cardRef.current.style.top = `${e.clientY - 44}px`;
+        cardRef.current.style.left = `${point.x - 150}px`;
+        cardRef.current.style.top = `${point.y - 44}px`;
       }
+    };
+
+    useEffect(() => {
+      editPoint(initialPosition);
     }, []);
 
     useEffect(() => {
@@ -46,11 +47,7 @@ export const CloneCard = memo(
 
     return (
       <div ref={cardRef} css={[cardStyle, cloneCardStyle]}>
-        <CardViewer
-          onClickEdit={() => {}}
-          onClickRemove={() => {}}
-          cardData={cardData}
-        />
+        <CardViewer cardData={cardData} />
       </div>
     );
   }

--- a/fe/src/components/Card/CloneCard.tsx
+++ b/fe/src/components/Card/CloneCard.tsx
@@ -1,5 +1,5 @@
 import { css } from "@emotion/react";
-import React, { useCallback, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useRef } from "react";
 import { CardData, cardStyle } from "./Card";
 import { CardViewer } from "./CardViewer";
 
@@ -7,8 +7,7 @@ export interface Position {
   x: number;
   y: number;
 }
-
-export const CloneCard = React.memo(
+export const CloneCard = memo(
   ({
     cardData,
     initialPosition,
@@ -16,30 +15,37 @@ export const CloneCard = React.memo(
     cardData: CardData;
     initialPosition: Position;
   }) => {
-    const [position, setPosition] = useState<Position>(initialPosition);
-    const positionRef = useRef(position);
-    positionRef.current = position;
+    const cardRef = useRef<HTMLDivElement>(null);
 
-    const moveCard = useCallback(
-      (e: React.MouseEvent) => {
-        setPosition({ x: e.clientX, y: e.clientY });
-      },
-      [setPosition]
-    );
+    useEffect(() => {
+      if (cardRef.current) {
+        cardRef.current.style.left = `${initialPosition.x - 150}px`;
+        cardRef.current.style.top = `${initialPosition.y - 44}px`;
+      }
+    }, [initialPosition]);
 
-    const handleMouseMove = (e: React.MouseEvent) => {
-      window.requestAnimationFrame(() => moveCard(e));
-    };
+    const moveCard = useCallback((e: MouseEvent) => {
+      if (cardRef.current) {
+        cardRef.current.style.left = `${e.clientX - 150}px`;
+        cardRef.current.style.top = `${e.clientY - 44}px`;
+      }
+    }, []);
+
+    useEffect(() => {
+      window.addEventListener("mousemove", moveCard);
+
+      return () => {
+        window.removeEventListener("mousemove", moveCard);
+      };
+    }, [moveCard]);
 
     const cloneCardStyle = css`
       position: fixed;
-      left: ${positionRef.current.x - 150}px;
-      top: ${positionRef.current.y - 44}px;
       background: white;
     `;
 
     return (
-      <div css={[cardStyle, cloneCardStyle]} onMouseMove={handleMouseMove}>
+      <div ref={cardRef} css={[cardStyle, cloneCardStyle]}>
         <CardViewer
           onClickEdit={() => {}}
           onClickRemove={() => {}}

--- a/fe/src/components/Column/Column.tsx
+++ b/fe/src/components/Column/Column.tsx
@@ -1,13 +1,11 @@
-import { Card, CardData } from "@components/Card/Card";
+import { Card, CardData, cardStyle } from "@components/Card/Card";
+import { CardViewer } from "@components/Card/CardViewer";
 import { NewCard } from "@components/Card/NewCard";
 import { Position } from "@components/Main";
 import React, { useState } from "react";
 import { ColumnHeader } from "./ColumnHeader";
 
-interface ColumnDataProps {
-  columnId: number;
-  columnName: string;
-  cards: CardData[];
+interface ColumnProps extends ColumnType {
   onCardChanged: () => void;
   setCloneCard: (cardData: CardData, initialPosition: Position) => void;
   cloneState: {
@@ -17,6 +15,12 @@ interface ColumnDataProps {
   };
 }
 
+export interface ColumnType {
+  columnId: number;
+  columnName: string;
+  cards: CardData[];
+}
+
 export const Column = ({
   columnId,
   columnName,
@@ -24,7 +28,7 @@ export const Column = ({
   onCardChanged,
   setCloneCard,
   cloneState,
-}: ColumnDataProps) => {
+}: ColumnProps) => {
   const [isAdding, setIsAdding] = useState<boolean>(false);
   const onAddCardClick = () => setIsAdding((prev) => !prev);
   const onAddCancelClick = () => setIsAdding(false);
@@ -32,13 +36,9 @@ export const Column = ({
 
   const isCloneValid = cloneState.hasClone && cloneState.cloneCardData;
 
-  const CloneCard = (
-    <div css={{ opacity: "0.5" }}>
-      <Card
-        cardData={cloneState.cloneCardData!}
-        onCardChanged={onCardChanged}
-        setCloneCard={setCloneCard}
-      />
+  const GhostCard = (
+    <div css={[cardStyle, { opacity: "0.5" }]}>
+      <CardViewer cardData={cloneState.cloneCardData!} />
     </div>
   );
 
@@ -67,7 +67,7 @@ export const Column = ({
       )}
       {cards.map((cardData, index) => (
         <React.Fragment key={`${index}_${cardData.cardId}`}>
-          {isCloneValid && cloneState.cardIndex === index && CloneCard}
+          {isCloneValid && cloneState.cardIndex === index && GhostCard}
           <Card
             key={`${index}_${cardData.cardId}`}
             cardData={cardData}
@@ -76,7 +76,7 @@ export const Column = ({
           />
         </React.Fragment>
       ))}
-      {isCloneValid && cloneState.cardIndex === cards.length && CloneCard}
+      {isCloneValid && cloneState.cardIndex === cards.length && GhostCard}
     </div>
   );
 };

--- a/fe/src/hooks/useFetch.ts
+++ b/fe/src/hooks/useFetch.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { http } from "utils/http";
 
 interface UseFetchProps<T = Record<string, unknown>> {
@@ -23,7 +23,7 @@ export const useFetch = <T extends Record<string, unknown>>({
   const [errorMsg, setErrorMsg] = useState("");
   const [loading, setLoading] = useState(false);
 
-  const fetch = async () => {
+  const fetch = useCallback(async () => {
     setLoading(true);
     try {
       const res = await http[method](url, body);
@@ -36,7 +36,7 @@ export const useFetch = <T extends Record<string, unknown>>({
     } finally {
       setLoading(false);
     }
-  };
+  }, [url, method, body]);
 
   useEffect(() => {
     if (autoFetch) {

--- a/fe/src/mocks/data.ts
+++ b/fe/src/mocks/data.ts
@@ -4,8 +4,8 @@ import { faker } from "@faker-js/faker";
 export function createRandomCard(cardId: number): CardData {
   return {
     cardId,
-    title: faker.internet.domainName(),
-    content: faker.word.words(),
+    cardTitle: faker.internet.domainName(),
+    cardContent: faker.word.words(),
     writer: "web",
   };
 }

--- a/fe/src/mocks/handlers.ts
+++ b/fe/src/mocks/handlers.ts
@@ -38,14 +38,14 @@ let columnData: Column[] = [
     cards: [
       {
         cardId: 3,
-        title: "HTML/CSS 공부하기",
-        content: "add, commit, push, rebase, merge",
+        cardTitle: "HTML/CSS 공부하기",
+        cardContent: "add, commit, push, rebase, merge",
         writer: "web",
       },
       {
         cardId: 20,
-        title: "블로그에 포스팅할 것",
-        content: "모던 자바스크립트 1장",
+        cardTitle: "블로그에 포스팅할 것",
+        cardContent: "모던 자바스크립트 1장",
         writer: "web",
       },
     ],
@@ -56,14 +56,14 @@ let columnData: Column[] = [
     cards: [
       {
         cardId: 40,
-        title: "HTML/CSS 공부하기",
-        content: "add, commit, push, rebase, merge",
+        cardTitle: "HTML/CSS 공부하기",
+        cardContent: "add, commit, push, rebase, merge",
         writer: "web",
       },
       {
         cardId: 30,
-        title: "블로그에 포스팅할 것",
-        content: "모던 자바스크립트 1장",
+        cardTitle: "블로그에 포스팅할 것",
+        cardContent: "모던 자바스크립트 1장",
         writer: "web",
       },
     ],
@@ -98,7 +98,7 @@ export const handlers = [
     return res(ctx.status(200), ctx.json(columnData));
   }),
 
-  rest.get("/api/histories", (req, res, ctx) => {
+  rest.get("/api/histories", (_, res, ctx) => {
     return res(ctx.status(200), ctx.json(historyData));
   }),
 
@@ -113,7 +113,7 @@ export const handlers = [
     return res(ctx.status(200), ctx.json(columnData));
   }),
 
-  rest.delete("/api/histories", (req, res, ctx) => {
+  rest.delete("/api/histories", (_, res, ctx) => {
     historyData = [];
 
     return res(ctx.status(200), ctx.json(historyData));
@@ -138,8 +138,8 @@ export const handlers = [
         if (card.cardId === Number(id)) {
           return {
             ...card,
-            title: changedCardTitle,
-            content: changedCardContent,
+            cardTitle: changedCardTitle,
+            cardContent: changedCardContent,
           };
         }
         return card;
@@ -171,8 +171,8 @@ export const handlers = [
       await req.json<CardAddRequestBody>();
     const newCard = {
       cardId: Number(faker.number.octal()),
-      title: cardTitle,
-      content: cardContent,
+      cardTitle: cardTitle,
+      cardContent: cardContent,
       writer: "web",
     };
 


### PR DESCRIPTION
## What is this PR?
- card move에 성능을 개선했습니다.
- card move에서 오류 사항 수정했습니다.

## Key changes
- card move를 진행시 마우스의 좌표가 변경되는 매 순간 화면의 모든 card를 재랜더링하여 card의 움직임이 부드럽지 못하며 느린 현상을 수정했습니다.
  - `리액트에서 부모 컴포넌트가 재랜더링 될 경우 자식 컴포넌트가 props가 변경되지 않아도 재랜더링된다.`
  - 위 사실을 이번 기회에 알게 되었는데, 저는 자식 컴포넌트가 props가 변경되지 않으면 재랜더링이 안된다고 알고 있었습니다.
  - 그래서 Card 컴포넌트에 Memo를 추가했습니다.
  - Card 컴포넌트에서 props로 받는 함수들에게 useCallback을 추가했습니다.
- card move를 진행시 빠른 속도로 마우스를 이동하면 마우스가 들고 있던 CloneCard를 놓치는 현상을 수정했습니다.
  - CloneCard 컴포넌트 내부에서 마우스 이동을 할 경우 마우스 좌표로 CloneCard의 top, left를 수정하고 있었습니다.
  - 이때 CloneCard가 이벤트를 처리하고 Style을 반영하는 속도 보다 빠르게 마우스를 움직여 CloneCard의 영역을 벗어나면 마우스를 놓쳤습니다.
  - 그래서 mouseMove 이벤트를 window에 할당하도록 변경했습니다.
- CloneCard에 position 상태를 굳이 state로 저장하지 않고 바로 해당 컴포넌트에 style로 지정했습니다.
  - state로 놓으면서 불필요한 렌더링이 될 거라 생각했습니다.
- Card 컴포넌트가 클릭될 때 클릭한 영역이 button이 아닌 경우에만 isMouseDown을 true로 변경하도록 수정했습니다.
- Card 컴포넌트에서 클릭된 곳이 button이 아니며 isMouseDown가 true인 경우에만 onMouseMoveHandler 함수가 동작 하도록 수정했습니다.
## 개선 전/후
<details>
  <summary>개선 전 동영상</summary>

https://github.com/todo-team-01/todo-max/assets/41321198/67851a25-05f2-4cc3-a531-6a90e8af895e

</details>

<details>
  <summary>개선 후 동영상</summary>

https://github.com/todo-team-01/todo-max/assets/41321198/aacbc973-df32-4828-a503-57e4fe48b281

</details>

## To reviewers
브런치에서 커밋을 하는 과정에서 조금 문제가 생겨 파일이 꼬이는 현상이 있어 파일이 조금 이상하게 수정되었을 수 있을 것 같습니다.
최대한 확인은 했지만 이번 pr 과는 관련 없지만 조이가 이전에 작업한 내용의 수정이나 지워짐이 있는지 한 번만 확인 부탁드립니다.