### PR TITLE
fix #79: 빈 컬럼으로 카드 이동이 불가하던 오류 수정

### DIFF
--- a/be/src/main/java/org/codesquad/todo/domain/card/CardManager.java
+++ b/be/src/main/java/org/codesquad/todo/domain/card/CardManager.java
@@ -23,6 +23,11 @@ public class CardManager {
 		cardValidator.validateColumn(columnId);
 		Long validId = cardReader.findById(cardId).getId();
 
+		if (topCardId == null && bottomCardId == null) {
+			cardValidator.validateNoCardInColumn(columnId);
+			return cardRepository.updatePosition(validId, columnId, 1024L);
+		}
+
 		if (topCardId == null) {
 			Long bottomPosition = cardReader.findByIdAndColumn(bottomCardId, columnId).getPosition();
 			cardValidator.validateMaxCardId(columnId, bottomCardId);

--- a/be/src/main/java/org/codesquad/todo/domain/card/CardRepository.java
+++ b/be/src/main/java/org/codesquad/todo/domain/card/CardRepository.java
@@ -52,7 +52,8 @@ public class CardRepository {
 	public Optional<Card> findByIdAndColumn(Long id, Long columnId) {
 		String sql = "SELECT id, title, content, column_id, position FROM card WHERE id = :id and column_id= :columnId";
 		return Optional.ofNullable(
-			DataAccessUtils.singleResult(jdbcTemplate.query(sql, Map.of("id", id,"columnId",columnId), CARD_ROW_MAPPER)));
+			DataAccessUtils.singleResult(
+				jdbcTemplate.query(sql, Map.of("id", id, "columnId", columnId), CARD_ROW_MAPPER)));
 	}
 
 	public List<Card> findAllByColumnId(Long columnId) {
@@ -75,37 +76,38 @@ public class CardRepository {
 		return jdbcTemplate.update(sql, Map.of("columnId", columnId));
 	}
 
-	public int updatePosition(Long id, Long columnId, Long changedPosition ) {
+	public int updatePosition(Long id, Long columnId, Long changedPosition) {
 		String sql = "UPDATE card SET column_id = :columnId, position = :changedPosition WHERE id = :id";
 		return jdbcTemplate.update(sql, Map.of("id", id, "columnId", columnId, "changedPosition", changedPosition));
 	}
 
-	public List<Long> findRankingById (Long columnId,Long topCardId,Long bottomCardId) {
+	public List<Long> findRankingById(Long columnId, Long topCardId, Long bottomCardId) {
 		String sql = "SELECT ranking "
 			+ "FROM ( "
 			+ "  SELECT id, RANK() OVER (ORDER BY position ASC) AS ranking "
 			+ "  FROM card where column_id = :columnId"
 			+ ") AS ranking "
 			+ "WHERE id = :topCardId or id = :bottomCardId ";
-		return jdbcTemplate.query(sql, Map.of("columnId",columnId,"topCardId",topCardId, "bottomCardId",bottomCardId),RANK_ROW_MAPPER);
+		return jdbcTemplate.query(sql,
+			Map.of("columnId", columnId, "topCardId", topCardId, "bottomCardId", bottomCardId), RANK_ROW_MAPPER);
 	}
 
 	public Boolean isMax(Long columnId, Long id) {
-		String sql ="SELECT "
+		String sql = "SELECT "
 			+ " CASE WHEN position = "
 			+ " (SELECT MAX(position) FROM card where column_id = :columnId ) "
 			+ " THEN 1 ELSE 0 END AS is_max_position "
 			+ " FROM card WHERE id = :id";
-		return jdbcTemplate.queryForObject(sql,Map.of("columnId", columnId, "id", id), Boolean.class);
+		return jdbcTemplate.queryForObject(sql, Map.of("columnId", columnId, "id", id), Boolean.class);
 	}
 
 	public Boolean isMin(Long columnId, Long id) {
-		String sql ="SELECT "
+		String sql = "SELECT "
 			+ " CASE WHEN position = "
 			+ " (SELECT MIN(position) FROM card where column_id = :columnId ) "
 			+ " THEN 1 ELSE 0 END AS is_min_position "
 			+ " FROM card WHERE id = :id";
-		return jdbcTemplate.queryForObject(sql,Map.of("columnId", columnId, "id", id), Boolean.class);
+		return jdbcTemplate.queryForObject(sql, Map.of("columnId", columnId, "id", id), Boolean.class);
 	}
 
 	public int delete(Long id) {
@@ -119,5 +121,9 @@ public class CardRepository {
 	private static final RowMapper<Long> RANK_ROW_MAPPER = (rs, rowNum) ->
 		rs.getLong("ranking");
 
+	public Boolean existsInColumn(Long columnId) {
+		String sql = "SELECT EXISTS(SELECT 1 FROM cards WHERE column_id = :columnId)";
+		return jdbcTemplate.queryForObject(sql, Map.of("columnId", columnId), Boolean.class);
+	}
 }
 

--- a/be/src/main/java/org/codesquad/todo/domain/card/CardValidator.java
+++ b/be/src/main/java/org/codesquad/todo/domain/card/CardValidator.java
@@ -31,13 +31,13 @@ public class CardValidator {
 		}
 	}
 
-	public void validateMaxCardId(Long columnId, Long id){
+	public void validateMaxCardId(Long columnId, Long id) {
 		if (!cardRepository.isMax(columnId, id)) {
 			throw new InvalidCardException();
 		}
 	}
 
-	public void validateMinCardId(Long columnId, Long id){
+	public void validateMinCardId(Long columnId, Long id) {
 		if (!cardRepository.isMin(columnId, id)) {
 			throw new InvalidCardException();
 		}
@@ -46,6 +46,12 @@ public class CardValidator {
 	public void validateSequentialCards(Long columnId, Long topCardId, Long bottomCardId) {
 		List<Long> rankings = cardReader.findRankingById(columnId, topCardId, bottomCardId);
 		if (rankings.get(1) - rankings.get(0) != 1) {
+			throw new InvalidCardException();
+		}
+	}
+
+	public void validateNoCardInColumn(Long columnId) {
+		if (cardRepository.existsInColumn(columnId)) {
 			throw new InvalidCardException();
 		}
 	}

--- a/be/src/test/java/org/codesquad/todo/domain/card/CardManagerTest.java
+++ b/be/src/test/java/org/codesquad/todo/domain/card/CardManagerTest.java
@@ -96,4 +96,20 @@ class CardManagerTest {
 		assertThat(updated).isEqualTo(3);
 	}
 
+	@DisplayName("빈 컬럼으로 카드 이동 시 카드의 position을 1024로 할당한다.")
+	@Test
+	void moveToEmptyColumn() {
+		// given
+		given(cardReader.findById(1L))
+			.willReturn(new Card(1L, "이동할 카드", "이동할 카드", 1L, 1024L));
+
+		given(cardRepository.updatePosition(1L, 2L, 1024L)).willReturn(1);
+
+		// when
+		int updated = cardManager.move(1L, 2L, null, null);
+
+		// then
+		assertThat(updated).isEqualTo(1);
+	}
+
 }

--- a/be/src/test/java/org/codesquad/todo/domain/card/CardValidatorTest.java
+++ b/be/src/test/java/org/codesquad/todo/domain/card/CardValidatorTest.java
@@ -60,28 +60,28 @@ public class CardValidatorTest {
 	@Test
 	void isMax() {
 		// given
-		given(cardRepository.isMax(any(),any())).willReturn(true);
+		given(cardRepository.isMax(any(), any())).willReturn(true);
 
 		// when // then
-		assertDoesNotThrow(() -> cardValidator.validateMaxCardId(1L,1L));
+		assertDoesNotThrow(() -> cardValidator.validateMaxCardId(1L, 1L));
 	}
 
 	@DisplayName("입력받은 bottom card의 position 값이 해당하는 컬럼에서 최댓값이 아니라면 예외가 발생한다.")
 	@Test
 	void isMaxFail() {
 		// given
-		given(cardRepository.isMax(any(),any())).willReturn(false);
+		given(cardRepository.isMax(any(), any())).willReturn(false);
 
 		// when // then
 		assertThrows(InvalidCardException.class,
-			() -> cardValidator.validateMaxCardId(1L,1L));
+			() -> cardValidator.validateMaxCardId(1L, 1L));
 	}
 
 	@DisplayName("입력받은 top card의 position 값이 해당하는 컬럼에서 최솟값인 경우 예외가 발생하지 않는다.")
 	@Test
 	void isMin() {
 		// given
-		given(cardRepository.isMin(any(),any())).willReturn(true);
+		given(cardRepository.isMin(any(), any())).willReturn(true);
 
 		// when // then
 		assertDoesNotThrow(() -> cardValidator.validateMinCardId(1L, 1L));
@@ -91,7 +91,7 @@ public class CardValidatorTest {
 	@Test
 	void isMinFail() {
 		// given
-		given(cardRepository.isMin(any(),any())).willReturn(false);
+		given(cardRepository.isMin(any(), any())).willReturn(false);
 
 		// when // then
 		assertThrows(InvalidCardException.class,
@@ -121,4 +121,14 @@ public class CardValidatorTest {
 			() -> cardValidator.validateSequentialCards(1L, 2L, 3L));
 	}
 
+	@DisplayName("비어있지 않은 컬럼으로 이동 시 top 또는 bottom cardId가 null인 경우 예외가 발생한다.")
+	@Test
+	void validateNoCardInColumn() {
+		// given
+		given(cardRepository.existsInColumn(any())).willReturn(true);
+
+		// when // then
+		assertThrows(InvalidCardException.class,
+			() -> cardValidator.validateNoCardInColumn(1L));
+	}
 }


### PR DESCRIPTION
## What is this PR?

빈 컬럼으로 카드를 이동이 불가하던 오류를 수정했습니다.

## Key changes

비어있지 않은 컬럼으로 이동 시 top card 또는 bottom card ID가 null인 경우 예외가 발생합니다.

## To reviewers
